### PR TITLE
Add basic PSR-2 styling and spacing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,9 @@
                   "src/gripcontrol.php"]
     },
     "target-dir": "fanout/php-gripcontrol",
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "scripts": {
+        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+    }
 }

--- a/src/channel.php
+++ b/src/channel.php
@@ -17,10 +17,9 @@ class Channel
     public $prev_id = null;
 
     // Initialize with the channel name and an optional previous ID.
-    public function __construct($name, $prev_id=null)
+    public function __construct($name, $prev_id = null)
     {
         $this->name = $name;
         $this->prev_id = $prev_id;
     }
 }
-?>

--- a/src/encoding.php
+++ b/src/encoding.php
@@ -16,16 +16,16 @@ class Encoding
     // Determine whether the specified data is binary or not.
     public static function is_binary_data($data)
     {
-        if (preg_match('!!u', $data))
+        if (preg_match('!!u', $data)) {
             return false;
+        }
         $characters = str_split($data);
-        foreach($characters as $character)
-        {
+        foreach ($characters as $character) {
             $ord_value = ord($character);
-            if ($ord_value < 0x20 or $ord_value >= 0x7f)
+            if ($ord_value < 0x20 or $ord_value >= 0x7f) {
                 return true;
+            }
         }
         return false;
     }
 }
-?>

--- a/src/gripcontrol.php
+++ b/src/gripcontrol.php
@@ -24,23 +24,22 @@ class GripControl
     // either a string representing the channel name, a Channel instance or an
     // array of Channel instances. The response parameter can be specified as
     // either a string representing the response body or a Response instance.
-    public static function create_hold($mode, $channels, $response,
-            $timeout=null)
+    public static function create_hold($mode, $channels, $response, $timeout = null)
     {
         $channels = self::parse_channels($channels);
         $ichannels = self::get_hold_channels($channels);
         $hold = array();
         $hold['mode'] = $mode;
         $hold['channels'] = $ichannels;
-        if (!is_null($timeout))
-        {
+        if (!is_null($timeout)) {
             $hold['timeout'] = $timeout;
         }
         $iresponse = self::get_hold_response($response);
         $instruct = array();
         $instruct['hold'] = $hold;
-        if (!is_null($iresponse))
+        if (!is_null($iresponse)) {
             $instruct['response'] = $iresponse;
+        }
         return json_encode($instruct);
     }
 
@@ -53,39 +52,42 @@ class GripControl
     {
         $uri = parse_url($uri);
         $params = array();
-        if (array_key_exists('query', $uri))
+        if (array_key_exists('query', $uri)) {
             parse_str($uri['query'], $params);
+        }
         $iss = null;
         $key = null;
-        if (array_key_exists('iss', $params))
-        {
+        if (array_key_exists('iss', $params)) {
             $iss = $params['iss'];
             unset($params['iss']);
         }
-        if (array_key_exists('key', $params))
-        {
+        if (array_key_exists('key', $params)) {
             $key = $params['key'];
             unset($params['key']);
         }
-        if (!is_null($key) && substr($key, 0, strlen('base64:'))
-                === 'base64:')
+        if (!is_null($key) && substr($key, 0, strlen('base64:')) === 'base64:') {
             $key = base64_decode(substr($key, 7));
+        }
         $qs = http_build_query($params);
         $path = $uri['path'];
-        if (substr($path, strlen($path) - 1) === '/')
+        if (substr($path, strlen($path) - 1) === '/') {
             $path = substr($path, 0, strlen($path) - 1);
+        }
         $port = '';
-        if (array_key_exists('port', $uri) && $uri['port'] != '' &&
-                $uri['port'] != '80')
+        if (array_key_exists('port', $uri) && $uri['port'] != '' && $uri['port'] != '80') {
             $port = ':' . $uri['port'];
+        }
         $control_uri = $uri['scheme'] . '://' . $uri['host'] . $port . $path;
-        if (!is_null($qs) && $qs != '')
+        if (!is_null($qs) && $qs != '') {
             $control_uri .= '?' . $qs;
+        }
         $out = array('control_uri' => $control_uri);
-        if (!is_null($iss))
+        if (!is_null($iss)) {
             $out['control_iss'] = $iss;
-        if (!is_null($key))
+        }
+        if (!is_null($key)) {
             $out['key'] = $key;
+        }
         return $out;
     }
 
@@ -94,13 +96,10 @@ class GripControl
     // Note that the token expiration is also verified.
     public static function validate_sig($token, $key)
     {
-        try
-        {
+        try {
             \Firebase\JWT\JWT::decode($token, $key, array('HS256', 'HS384', 'HS512' and 'RS256'));
             return true;
-        }
-        catch (\Exception $e)
-        {
+        } catch (\Exception $e) {
             return false;
         }
     }
@@ -114,11 +113,11 @@ class GripControl
     {
         $channels = self::parse_channels($channels);
         $parts = array();
-        foreach ($channels as $channel)
-        {
+        foreach ($channels as $channel) {
             $s = $channel->name;
-            if (!is_null($channel->prev_id))
+            if (!is_null($channel->prev_id)) {
                 $s .= "; prev-id={$channel->prev_id}";
+            }
             $parts[] = $s;
         }
         return implode(', ', $parts);
@@ -127,8 +126,7 @@ class GripControl
     // A convenience method for creating GRIP hold response instructions for HTTP
     // long-polling. This method simply passes the specified parameters to the
     // create_hold method with 'response' as the hold mode.
-    public static function create_hold_response($channels, $response=null,
-            $timeout=null)
+    public static function create_hold_response($channels, $response = null, $timeout = null)
     {
         return self::create_hold('response', $channels, $response, $timeout);
     }
@@ -136,7 +134,7 @@ class GripControl
     // A convenience method for creating GRIP hold stream instructions for HTTP
     // streaming. This method simply passes the specified parameters to the
     // create_hold method with 'stream' as the hold mode.
-    public static function create_hold_stream($channels, $response=null)
+    public static function create_hold_stream($channels, $response = null)
     {
         return self::create_hold('stream', $channels, $response);
     }
@@ -148,25 +146,24 @@ class GripControl
     {
         $out = array();
         $start = 0;
-        while ($start < strlen($body))
-        {
+        while ($start < strlen($body)) {
             $at = strpos($body, "\r\n", $start);
-            if ($at === false)
+            if ($at === false) {
                 throw new \RuntimeException('bad format');
+            }
             $typeline = substr($body, $start, $at - $start);
             $start = $at + 2;
             $at = strpos($typeline, ' ');
             $e = null;
-            if (!($at === false))
-            {
+            if (!($at === false)) {
                 $etype = substr($typeline, 0, $at);
                 $clen = intval('0x' . substr($typeline, $at + 1), 16);
                 $content = substr($body, $start, $clen);
                 $start += $clen + 2;
                 $e = new WebSocketEvent($etype, $content);
-            }
-            else
+            } else {
                 $e = new WebSocketEvent($typeline);
+            }
             $out[] = $e;
         }
         return $out;
@@ -178,16 +175,14 @@ class GripControl
     public static function encode_websocket_events($events)
     {
         $out = '';
-        foreach ($events as $event)
-        {
-            if (!is_null($event->content))
-            {
+        foreach ($events as $event) {
+            if (!is_null($event->content)) {
                 $content_length = dechex(strlen($event->content));
                 $out .= "{$event->type} {$content_length}\r\n" .
                         "{$event->content}\r\n";
-            }
-            else
+            } else {
                 $out .= "{$event->type}\r\n";
+            }
         }
         return $out;
     }
@@ -196,11 +191,12 @@ class GripControl
     // arguments. WebSocket control messages are passed to GRIP proxies and
     // example usage includes subscribing/unsubscribing a WebSocket connection
     // to/from a channel.
-    public static function websocket_control_message($type, $args=null)
+    public static function websocket_control_message($type, $args = null)
     {
         $out = array();
-        if (!is_null($args))
+        if (!is_null($args)) {
             $out = $args;
+        }
         $out['type'] = $type;
         return json_encode($out);
     }
@@ -210,12 +206,14 @@ class GripControl
     // Channel instance, or an array of Channel instances.
     protected static function parse_channels($channels)
     {
-        if ($channels instanceof Channel)
+        if ($channels instanceof Channel) {
             $channels = array($channels);
-        elseif (is_string($channels))
+        } elseif (is_string($channels)) {
             $channels = array(new Channel($channels));
-        if (count($channels) == 0)
+        }
+        if (count($channels) == 0) {
             throw new \RuntimeException('channels length is 0');
+        }
         return $channels;
     }
 
@@ -225,14 +223,15 @@ class GripControl
     protected static function get_hold_channels($channels)
     {
         $ichannels = array();
-        foreach ($channels as $channel)
-        {
-            if (is_string($channel))
+        foreach ($channels as $channel) {
+            if (is_string($channel)) {
                 $channel = new Channel($channel);
+            }
             $ichannel = array();
             $ichannel['name'] = $channel->name;
-            if (!is_null($channel->prev_id))
+            if (!is_null($channel->prev_id)) {
                 $ichannel['prev-id'] = $channel->prev_id;
+            }
             $ichannels[] = $ichannel;
         }
         return $ichannels;
@@ -244,27 +243,28 @@ class GripControl
     protected static function get_hold_response($response)
     {
         $iresponse = null;
-        if (!is_null($response))
-        {
-            if (is_string($response))
+        if (!is_null($response)) {
+            if (is_string($response)) {
                 $response = new Response(null, null, null, $response);
+            }
             $iresponse = array();
-            if (!is_null($response->code))
+            if (!is_null($response->code)) {
                 $iresponse['code'] = $response->code;
-            if (!is_null($response->reason))
+            }
+            if (!is_null($response->reason)) {
                 $iresponse['reason'] = $response->reason;
-            if (!is_null($response->headers) && count($response->headers) > 0)
+            }
+            if (!is_null($response->headers) && count($response->headers) > 0) {
                 $iresponse['headers'] = $response->headers;
-            if (!is_null($response->body))
-            {
-                if (Encoding::is_binary_data($response->body))
+            }
+            if (!is_null($response->body)) {
+                if (Encoding::is_binary_data($response->body)) {
                     $iresponse['body-bin'] = base64_encode($response->body);
-                else
+                } else {
                     $iresponse['body'] = $response->body;
+                }
             }
         }
         return $iresponse;
     }
 }
-
-?>

--- a/src/grippubcontrol.php
+++ b/src/grippubcontrol.php
@@ -19,12 +19,13 @@ class GripPubControl extends \PubControl\PubControl
 {
     // Initialize with or without a configuration. A configuration can be applied
     // after initialization via the apply_grip_config method.
-    public function __construct($config=null)
+    public function __construct($config = null)
     {
         $this->clients = array();
         $this->pcccbhandlers = array();
-        if (!is_null($config))
+        if (!is_null($config)) {
             $this->apply_grip_config($config);
+        }
     }
 
     // Apply the specified configuration to this GripPubControl instance. The
@@ -34,16 +35,17 @@ class GripPubControl extends \PubControl\PubControl
     // a URI or a URI and JWT authentication information.
     public function apply_grip_config($config)
     {
-        if (!is_array(reset($config)))
+        if (!is_array(reset($config))) {
             $config = array($config);
-        foreach ($config as $entry)
-        {
-            if (!array_key_exists('control_uri', $entry))
-                continue;    
+        }
+        foreach ($config as $entry) {
+            if (!array_key_exists('control_uri', $entry)) {
+                continue;
+            }
             $pub = new \PubControl\PubControlClient($entry['control_uri']);
-            if (array_key_exists('control_iss', $entry))
-                $pub->set_auth_jwt(array('iss' => $entry['control_iss']), 
-                        $entry['key']);
+            if (array_key_exists('control_iss', $entry)) {
+                $pub->set_auth_jwt(array('iss' => $entry['control_iss']), $entry['key']);
+            }
             $this->clients[] = $pub;
         }
     }
@@ -54,12 +56,11 @@ class GripPubControl extends \PubControl\PubControl
     // be provided as either an HttpResponseFormat instance or a string (in which
     // case an HttpResponseFormat instance will automatically be created and
     // have the 'body' field set to the specified string).
-    public function publish_http_response($channel, $http_response,
-            $id=null, $prev_id=null)
+    public function publish_http_response($channel, $http_response, $id = null, $prev_id = null)
     {
-        if (is_string($http_response))
-            $http_response = new HttpResponseFormat(null, null, null,
-                    $http_response);
+        if (is_string($http_response)) {
+            $http_response = new HttpResponseFormat(null, null, null, $http_response);
+        }
         $item = new \PubControl\Item($http_response, $id, $prev_id);
         parent::publish($channel, $item);
     }
@@ -72,12 +73,11 @@ class GripPubControl extends \PubControl\PubControl
     // be created and have the 'body' field set to the specified string). When
     // specified, the callback method will be called after publishing is complete
     // and passed a result and error message (if an error was encountered).
-    public function publish_http_response_async($channel, $http_response,
-            $id=null, $prev_id=null, $callback=null)
+    public function publish_http_response_async($channel, $http_response, $id = null, $prev_id = null, $callback = null)
     {
-        if (is_string($http_response))
-            $http_response = new HttpResponseFormat(null, null, null,
-                    $http_response);
+        if (is_string($http_response)) {
+            $http_response = new HttpResponseFormat(null, null, null, $http_response);
+        }
         $item = new \PubControl\Item($http_response, $id, $prev_id);
         parent::publish_async($channel, $item, $callback);
     }
@@ -88,11 +88,11 @@ class GripPubControl extends \PubControl\PubControl
     // be provided as either an HttpStreamFormat instance or a string (in which
     // case an HttStreamFormat instance will automatically be created and
     // have the 'content' field set to the specified string).
-    public function publish_http_stream($channel, $http_stream,
-            $id=null, $prev_id=null)
+    public function publish_http_stream($channel, $http_stream, $id = null, $prev_id = null)
     {
-        if (is_string($http_stream))
+        if (is_string($http_stream)) {
             $http_stream = new HttpStreamFormat($http_stream);
+        }
         $item = new \PubControl\Item($http_stream, $id, $prev_id);
         parent::publish($channel, $item);
     }
@@ -105,13 +105,12 @@ class GripPubControl extends \PubControl\PubControl
     // be created and have the 'content' field set to the specified string). When
     // specified, the callback method will be called after publishing is complete
     // and passed a result and error message (if an error was encountered).
-    public function publish_http_stream_async($channel, $http_stream,
-            $id=null, $prev_id=null, $callback=null)
+    public function publish_http_stream_async($channel, $http_stream, $id = null, $prev_id = null, $callback = null)
     {
-        if (is_string($http_stream))
+        if (is_string($http_stream)) {
             $http_stream = new HttpStreamFormat($http_stream);
+        }
         $item = new \PubControl\Item($http_stream, $id, $prev_id);
         parent::publish_async($channel, $item, $callback);
     }
 }
-?>

--- a/src/httpresponseformat.php
+++ b/src/httpresponseformat.php
@@ -20,8 +20,7 @@ class HttpResponseFormat extends \PubControl\Format
 
     // Initialize with the message code, reason, headers, and body to send
     // to the client when the message is published.
-    public function __construct($code=null, $reason=null,
-            $headers=null, $body=null)
+    public function __construct($code = null, $reason = null, $headers = null, $body = null)
     {
         $this->code = $code;
         $this->reason = $reason;
@@ -41,20 +40,22 @@ class HttpResponseFormat extends \PubControl\Format
     public function export()
     {
         $out = array();
-        if (!is_null($this->code))
+        if (!is_null($this->code)) {
             $out['code'] = $this->code;
-        if (!is_null($this->reason))
+        }
+        if (!is_null($this->reason)) {
             $out['reason'] = $this->reason;
-        if (!is_null($this->headers))
+        }
+        if (!is_null($this->headers)) {
             $out['headers'] = $this->headers;
-        if (!is_null($this->body))
-        {
-            if (Encoding::is_binary_data($this->body))
+        }
+        if (!is_null($this->body)) {
+            if (Encoding::is_binary_data($this->body)) {
                 $out['body-bin'] = base64_encode($this->body);
-            else
+            } else {
                 $out['body'] = $this->body;
+            }
         }
         return $out;
     }
 }
-?>

--- a/src/httpstreamformat.php
+++ b/src/httpstreamformat.php
@@ -19,12 +19,13 @@ class HttpStreamFormat extends \PubControl\Format
     // Initialize with either the message content or a boolean indicating that
     // the streaming connection should be closed. If neither the content nor
     // the boolean flag is set then an error will be raised.
-    public function __construct($content=null, $close=false)
+    public function __construct($content = null, $close = false)
     {
         $this->content = $content;
         $this->close = $close;
-        if (!$this->close && is_null($this->content))
+        if (!$this->close && is_null($this->content)) {
             throw new \RuntimeException('Content not set');
+        }
     }
 
     // The name used when publishing this format.
@@ -39,16 +40,15 @@ class HttpStreamFormat extends \PubControl\Format
     public function export()
     {
         $out = array();
-        if ($this->close)
+        if ($this->close) {
             $out['action'] = 'close';
-        else
-        {
-            if (Encoding::is_binary_data($this->content))
+        } else {
+            if (Encoding::is_binary_data($this->content)) {
                 $out['content-bin'] = base64_encode($this->content);
-            else
+            } else {
                 $out['content'] = $this->content;
+            }
         }
         return $out;
     }
 }
-?>

--- a/src/response.php
+++ b/src/response.php
@@ -12,7 +12,7 @@ namespace GripControl;
 // The Response class is used to represent a set of HTTP response data.
 // Populated instances of this class are serialized to JSON and passed
 // to the GRIP proxy in the body. The GRIP proxy then parses the message
-// and deserialized the JSON into an HTTP response that is passed back 
+// and deserialized the JSON into an HTTP response that is passed back
 // to the client.
 class Response
 {
@@ -22,8 +22,7 @@ class Response
     public $body = null;
 
     // Initialize with an HTTP response code, reason, headers, and body.
-    public function __construct($code=null, $reason=null,
-            $headers=null, $body=null)
+    public function __construct($code = null, $reason = null, $headers = null, $body = null)
     {
         $this->code = $code;
         $this->reason = $reason;
@@ -31,4 +30,3 @@ class Response
         $this->body = $body;
     }
 }
-?>

--- a/src/websocketevent.php
+++ b/src/websocketevent.php
@@ -18,10 +18,9 @@ class WebSocketEvent
     public $content = null;
 
     // Initialize with a specified event type and optional content information.
-    public function __construct($type, $content=null)
+    public function __construct($type, $content = null)
     {
         $this->type = $type;
         $this->content = $content;
     }
 }
-?>

--- a/src/websocketmessageformat.php
+++ b/src/websocketmessageformat.php
@@ -31,13 +31,13 @@ class WebSocketMessageFormat extends \PubControl\Format
     // Exports the message in the required format depending on whether the
     // message content is binary or not.
     public function export()
-    {        
+    {
         $out = array();
-        if (Encoding::is_binary_data($this->content))
+        if (Encoding::is_binary_data($this->content)) {
             $out['content-bin'] = base64_encode($this->content);
-        else
+        } else {
             $out['content'] = $this->content;
+        }
         return $out;
     }
 }
-?>

--- a/tests/channel_tests.php
+++ b/tests/channel_tests.php
@@ -12,5 +12,3 @@ class ChannelTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($ch->prev_id, 'prev-id');
     }
 }
-
-?>

--- a/tests/encoding_tests.php
+++ b/tests/encoding_tests.php
@@ -8,5 +8,3 @@ class EncodingTests extends PHPUnit_Framework_TestCase
         $this->assertTrue(GripControl\Encoding::is_binary_data("\x04\x00\xa0\x00"));
     }
 }
-
-?>

--- a/tests/gripcontrol_tests.php
+++ b/tests/gripcontrol_tests.php
@@ -30,22 +30,22 @@ class GripControlTests extends PHPUnit_Framework_TestCase
 
     public function testCreateHold()
     {
-        $hold = json_decode(GripControl\GripControl::create_hold('mode', 'channel',
-                new GripControl\Response('code', 'reason', 'headers', 'body')));
+        $hold = json_decode(GripControl\GripControl::create_hold(
+            'mode',
+            'channel',
+            new GripControl\Response('code', 'reason', 'headers', 'body')
+        ));
         $this->assertEquals($hold->hold->mode, 'mode');
-        $this->assertEquals($hold->hold->channels[0]->name,
-                'channel');
+        $this->assertEquals($hold->hold->channels[0]->name, 'channel');
         $this->assertFalse(array_key_exists('timeout', $hold->hold));
         $this->assertEquals($hold->response->code, 'code');
         $this->assertEquals($hold->response->reason, 'reason');
         $this->assertEquals($hold->response->headers, 'headers');
         $this->assertEquals($hold->response->body, 'body');
-        $hold = json_decode(GripControl\GripControl::create_hold('mode', 'channel',
-                'body', 'timeout'));
+        $hold = json_decode(GripControl\GripControl::create_hold('mode', 'channel', 'body', 'timeout'));
         $this->assertEquals($hold->hold->mode, 'mode');
         $this->assertEquals($hold->hold->timeout, 'timeout');
-        $this->assertEquals($hold->hold->channels[0]->name,
-                'channel');
+        $this->assertEquals($hold->hold->channels[0]->name, 'channel');
         $this->assertFalse(array_key_exists('code', $hold->response));
         $this->assertFalse(array_key_exists('reason', $hold->response));
         $this->assertFalse(array_key_exists('headers', $hold->response));
@@ -53,53 +53,38 @@ class GripControlTests extends PHPUnit_Framework_TestCase
     }
 
     public function testParseGripUri()
-    {  
-        $uri = 'http://api.fanout.io/realm/realm?iss=realm' .
-                '&key=base64:geag121321=';
+    {
+        $uri = 'http://api.fanout.io/realm/realm?iss=realm&key=base64:geag121321=';
         $config = GripControl\GripControl::parse_grip_uri($uri);
-        $this->assertEquals($config['control_uri'],
-                'http://api.fanout.io/realm/realm');
+        $this->assertEquals($config['control_uri'], 'http://api.fanout.io/realm/realm');
         $this->assertEquals($config['control_iss'], 'realm');
         $this->assertEquals($config['key'], base64_decode('geag121321='));
-        $uri = 'https://api.fanout.io/realm/realm?iss=realm' .
-                '&key=base64:geag121321=';
+        $uri = 'https://api.fanout.io/realm/realm?iss=realm&key=base64:geag121321=';
         $config = GripControl\GripControl::parse_grip_uri($uri);
-        $this->assertEquals($config['control_uri'],
-                'https://api.fanout.io/realm/realm');
-        $config = GripControl\GripControl::parse_grip_uri(
-                'http://api.fanout.io/realm/realm');
-        $this->assertEquals($config['control_uri'],
-                'http://api.fanout.io/realm/realm');
+        $this->assertEquals($config['control_uri'], 'https://api.fanout.io/realm/realm');
+        $config = GripControl\GripControl::parse_grip_uri('http://api.fanout.io/realm/realm');
+        $this->assertEquals($config['control_uri'], 'http://api.fanout.io/realm/realm');
         $this->assertEquals(array_key_exists('control_iss', $config), false);
         $this->assertEquals(array_key_exists('key', $config), false);
-        $uri = 'http://api.fanout.io/realm/realm?iss=realm' .
-                '&key=base64:geag121321=&param1=value1&param2=value2';
+        $uri = 'http://api.fanout.io/realm/realm?iss=realm&key=base64:geag121321=&param1=value1&param2=value2';
         $config = GripControl\GripControl::parse_grip_uri($uri);
-        $this->assertEquals($config['control_uri'],
-                'http://api.fanout.io/realm/realm?' .
-                'param1=value1&param2=value2');
+        $this->assertEquals($config['control_uri'], 'http://api.fanout.io/realm/realm?param1=value1&param2=value2');
         $this->assertEquals($config['control_iss'], 'realm');
         $this->assertEquals($config['key'], base64_decode('geag121321='));
-        $config = GripControl\GripControl::parse_grip_uri(
-                'http://api.fanout.io:8080/realm/realm/');
-        $this->assertEquals($config['control_uri'],
-                'http://api.fanout.io:8080/realm/realm');
-        $uri = 'http://api.fanout.io/realm/realm?iss=realm' .
-                '&key=geag121321=';
+        $config = GripControl\GripControl::parse_grip_uri('http://api.fanout.io:8080/realm/realm/');
+        $this->assertEquals($config['control_uri'], 'http://api.fanout.io:8080/realm/realm');
+        $uri = 'http://api.fanout.io/realm/realm?iss=realm&key=geag121321=';
         $config = GripControl\GripControl::parse_grip_uri($uri);
         $this->assertEquals($config['key'], 'geag121321=');
     }
 
     public function testValidateSig()
     {
-        $token = \Firebase\JWT\JWT::encode(array('iss' => 'realm', 'exp' => time() + 3600),
-                'key');
+        $token = \Firebase\JWT\JWT::encode(array('iss' => 'realm', 'exp' => time() + 3600), 'key');
         assert(GripControl\GripControl::validate_sig($token, 'key'));
-        $token = \Firebase\JWT\JWT::encode(array('iss' => 'realm', 'exp' => time() - 3600),
-                'key');
+        $token = \Firebase\JWT\JWT::encode(array('iss' => 'realm', 'exp' => time() - 3600), 'key');
         $this->assertEquals(GripControl\GripControl::validate_sig($token, 'key'), false);
-        $token = \Firebase\JWT\JWT::encode(array('iss' => 'realm', 'exp' => time() + 3600),
-                'key');
+        $token = \Firebase\JWT\JWT::encode(array('iss' => 'realm', 'exp' => time() + 3600), 'key');
         $this->assertEquals(GripControl\GripControl::validate_sig($token, 'wrong_key'), false);
     }
 
@@ -117,28 +102,33 @@ class GripControlTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($header, 'channel');
         $header = GripControl\GripControl::create_grip_channel_header(new GripControl\Channel('channel'));
         $this->assertEquals($header, 'channel');
-        $header = GripControl\GripControl::create_grip_channel_header(new GripControl\Channel('channel',
-                'prev-id'));
+        $header = GripControl\GripControl::create_grip_channel_header(new GripControl\Channel('channel', 'prev-id'));
         $this->assertEquals($header, 'channel; prev-id=prev-id');
         $header = GripControl\GripControl::create_grip_channel_header(array(
-                new GripControl\Channel('channel1',
-                'prev-id1'), new GripControl\Channel('channel2', 'prev-id2')));
-        $this->assertEquals($header,
-                'channel1; prev-id=prev-id1, channel2; prev-id=prev-id2');
+            new GripControl\Channel('channel1', 'prev-id1'), new GripControl\Channel('channel2', 'prev-id2')
+        ));
+        $this->assertEquals($header, 'channel1; prev-id=prev-id1, channel2; prev-id=prev-id2');
     }
 
     public function testCreateHoldResponse()
     {
-        $hold = json_decode(GripControl\GripControl::create_hold_response('channel',
-                new GripControl\Response('code', 'reason', 'headers', 'body')), true);
+        $hold = json_decode(GripControl\GripControl::create_hold_response(
+            'channel',
+            new GripControl\Response('code', 'reason', 'headers', 'body')
+        ), true);
         $this->assertEquals($hold['hold']['mode'], 'response');
         $this->assertEquals(array_key_exists('timeout', $hold['hold']), false);
-        $this->assertEquals($hold['hold']['channels'],
-                array(array('name' => 'channel')));
-        $this->assertEquals($hold['response'], array('code' => 'code',
-                'reason' => 'reason', 'headers' => 'headers', 'body' => 'body'));
-        $hold = json_decode(GripControl\GripControl::create_hold_response('channel', null,
-                'timeout'), true);
+        $this->assertEquals(
+            $hold['hold']['channels'],
+            array(array('name' => 'channel'))
+        );
+        $this->assertEquals($hold['response'], array(
+            'code' => 'code',
+            'reason' => 'reason',
+            'headers' => 'headers',
+            'body' => 'body'
+        ));
+        $hold = json_decode(GripControl\GripControl::create_hold_response('channel', null, 'timeout'), true);
         $this->assertFalse(array_key_exists('response', $hold));
         $this->assertEquals($hold['hold']['mode'], 'response');
         $this->assertEquals($hold['hold']['timeout'], 'timeout');
@@ -147,13 +137,20 @@ class GripControlTests extends PHPUnit_Framework_TestCase
     public function testCreateHoldStream()
     {
         $hold = json_decode(GripControl\GripControl::create_hold_stream('channel', new GripControl\Response(
-                'code', 'reason', 'headers', 'body')), true);
+            'code',
+            'reason',
+            'headers',
+            'body'
+        )), true);
         $this->assertEquals($hold['hold']['mode'], 'stream');
         $this->assertEquals(array_key_exists('timeout', $hold['hold']), false);
-        $this->assertEquals($hold['hold']['channels'], array(array(
-                'name' => 'channel')));
-        $this->assertEquals($hold['response'], array('code' => 'code',
-                'reason' => 'reason', 'headers' => 'headers', 'body' => 'body'));
+        $this->assertEquals($hold['hold']['channels'], array(array('name' => 'channel')));
+        $this->assertEquals($hold['response'], array(
+            'code' => 'code',
+            'reason' => 'reason',
+            'headers' => 'headers',
+            'body' => 'body'
+        ));
         $hold = json_decode(GripControl\GripControl::create_hold_stream('channel', null), true);
         $this->assertFalse(array_key_exists('response', $hold));
         $this->assertEquals($hold['hold']['mode'], 'stream');
@@ -177,8 +174,9 @@ class GripControlTests extends PHPUnit_Framework_TestCase
 
     public function testDecodeWebSocketEvents()
     {
-        $events = GripControl\GripControl::decode_websocket_events("OPEN\r\nTEXT 5\r\nHello" . 
-                "\r\nTEXT 0\r\n\r\nCLOSE\r\nTEXT\r\nCLOSE\r\n");
+        $events = GripControl\GripControl::decode_websocket_events(
+            "OPEN\r\nTEXT 5\r\nHello\r\nTEXT 0\r\n\r\nCLOSE\r\nTEXT\r\nCLOSE\r\n"
+        );
         $this->assertEquals(count($events), 6);
         $this->assertEquals($events[0]->type, 'OPEN');
         $this->assertEquals($events[0]->content, null);
@@ -203,14 +201,14 @@ class GripControlTests extends PHPUnit_Framework_TestCase
     }
 
     public function testEncodeWebSocketEvents()
-    {  
+    {
         $events = GripControl\GripControl::encode_websocket_events(array(
-                new GripControl\WebSocketEvent("TEXT", "Hello"), 
+                new GripControl\WebSocketEvent("TEXT", "Hello"),
                 new GripControl\WebSocketEvent("TEXT", ""),
-                new GripControl\WebSocketEvent("TEXT", null)));
+                new GripControl\WebSocketEvent("TEXT", null)
+        ));
         $this->assertEquals($events, "TEXT 5\r\nHello\r\nTEXT 0\r\n\r\nTEXT\r\n");
-        $events = GripControl\GripControl::encode_websocket_events(array(
-                new GripControl\WebSocketEvent("OPEN")));
+        $events = GripControl\GripControl::encode_websocket_events(array(new GripControl\WebSocketEvent("OPEN")));
         $this->assertEquals($events, "OPEN\r\n");
     }
 
@@ -218,9 +216,10 @@ class GripControlTests extends PHPUnit_Framework_TestCase
     {
         $message = GripControl\GripControl::websocket_control_message('type');
         $this->assertEquals($message, '{"type":"type"}');
-        $message = json_decode(GripControl\GripControl::websocket_control_message(
-                'type', array('arg1' => 'val1',
-                'arg2' => 'val2')), true);
+        $message = json_decode(GripControl\GripControl::websocket_control_message('type', array(
+            'arg1' => 'val1',
+            'arg2' => 'val2'
+        )), true);
         $this->assertEquals($message['type'], 'type');
         $this->assertEquals($message['arg1'], 'val1');
         $this->assertEquals($message['arg2'], 'val2');
@@ -242,13 +241,13 @@ class GripControlTests extends PHPUnit_Framework_TestCase
         $channels = GripControlTestClass::callParsechannels(new GripControl\Channel('channel'));
         $this->assertEquals($channels[0]->name, 'channel');
         $this->assertEquals($channels[0]->prev_id, null);
-        $channels = GripControlTestClass::callParsechannels(
-                new GripControl\Channel('channel', 'prev-id'));
+        $channels = GripControlTestClass::callParsechannels(new GripControl\Channel('channel', 'prev-id'));
         $this->assertEquals($channels[0]->name, 'channel');
         $this->assertEquals($channels[0]->prev_id, 'prev-id');
         $channels = GripControlTestClass::callParsechannels(array(
-                new GripControl\Channel('channel1', 'prev-id'),
-                new GripControl\Channel('channel2')));
+            new GripControl\Channel('channel1', 'prev-id'),
+            new GripControl\Channel('channel2')
+        ));
         $this->assertEquals($channels[0]->name, 'channel1');
         $this->assertEquals($channels[0]->prev_id, 'prev-id');
         $this->assertEquals($channels[1]->name, 'channel2');
@@ -257,20 +256,18 @@ class GripControlTests extends PHPUnit_Framework_TestCase
 
     public function testGetHoldChannels()
     {
-        $hold_channels = GripControlTestClass::callGetHoldChannels(
-                array(new GripControl\Channel('channel')));
+        $hold_channels = GripControlTestClass::callGetHoldChannels(array(new GripControl\Channel('channel')));
         $this->assertEquals($hold_channels[0], array('name' => 'channel'));
         $hold_channels = GripControlTestClass::callGetHoldChannels(array(
-                new GripControl\Channel('channel', 'prev-id')));
-        $this->assertEquals($hold_channels[0], array('name' => 'channel', 'prev-id' =>
-                'prev-id'));
+            new GripControl\Channel('channel', 'prev-id')
+        ));
+        $this->assertEquals($hold_channels[0], array('name' => 'channel', 'prev-id' => 'prev-id'));
         $hold_channels = GripControlTestClass::callGetHoldChannels(array(
-                new GripControl\Channel('channel1', 'prev-id1'),
-                new GripControl\Channel('channel2', 'prev-id2')));
-        $this->assertEquals($hold_channels[0], array('name' => 'channel1', 'prev-id' =>
-                'prev-id1'));
-        $this->assertEquals($hold_channels[1], array('name' => 'channel2', 'prev-id' =>
-                'prev-id2'));
+            new GripControl\Channel('channel1', 'prev-id1'),
+            new GripControl\Channel('channel2', 'prev-id2')
+        ));
+        $this->assertEquals($hold_channels[0], array('name' => 'channel1', 'prev-id' => 'prev-id1'));
+        $this->assertEquals($hold_channels[1], array('name' => 'channel2', 'prev-id' => 'prev-id2'));
     }
 
     public function testGetHoldResponse()
@@ -285,19 +282,25 @@ class GripControlTests extends PHPUnit_Framework_TestCase
         // Verify non-UTF8 data passed as the body is exported as content-bin
         $response = GripControlTestClass::callGetHoldResponse("\x04\x00\xa0\x00");
         $this->assertEquals($response['body-bin'], base64_encode("\x04\x00\xa0\x00"));
-        $response = GripControlTestClass::callGetHoldResponse(new GripControl\Response('code', 'reason',
-                array('header1' => 'val1'), "body\u2713"));
+        $response = GripControlTestClass::callGetHoldResponse(new GripControl\Response(
+            'code',
+            'reason',
+            array('header1' => 'val1'),
+            "body\u2713"
+        ));
         $this->assertEquals($response['code'], 'code');
         $this->assertEquals($response['reason'], 'reason');
         $this->assertEquals($response['headers'], array('header1' => 'val1'));
         $this->assertEquals($response['body'], "body\u2713");
         $response = GripControlTestClass::callGetHoldResponse(new GripControl\Response(
-                null, null, array(), null));
+            null,
+            null,
+            array(),
+            null
+        ));
         $this->assertEquals(array_key_exists('headers', $response), false);
         $this->assertEquals(array_key_exists('body', $response), false);
         $this->assertEquals(array_key_exists('reason', $response), false);
         $this->assertEquals(array_key_exists('headers', $response), false);
     }
 }
-
-?>

--- a/tests/grippubcontrol_tests.php
+++ b/tests/grippubcontrol_tests.php
@@ -22,7 +22,7 @@ class PubControlClientTestClass
 
     public function finish()
     {
-        $this->was_finish_called = true;   
+        $this->was_finish_called = true;
     }
 
     public function publish($channel, $item)
@@ -39,7 +39,7 @@ class PubControlClientAsyncTestClass
     public $publish_item = null;
     public $publish_cb = null;
 
-    public function publish_async($channel, $item, $callback=null)
+    public function publish_async($channel, $item, $callback = null)
     {
         $this->publish_channel = $channel;
         $this->publish_item = $item;
@@ -80,52 +80,58 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $pc = new GripPubControlTestClass();
         $this->assertEquals(count($pc->getClients()), 0);
         $this->assertEquals(count($pc->getPcccbHandlers()), 0);
-        $pc = new GripPubControlTestClass(array(array(
+        $pc = new GripPubControlTestClass(array(
+            array(
                 'control_uri' => 'uri',
                 'control_iss' => 'iss',
-                'key' => 'key=='),
-                array('control_uri' => 'uri2',
+                'key' => 'key=='
+            ),
+            array(
+                'control_uri' => 'uri2',
                 'control_iss' => 'iss2',
-                'key' => 'key==2')));
+                'key' => 'key==2'
+            )
+        ));
         $this->assertEquals(count($pc->getClients()), 2);
         $this->assertEquals(count($pc->getPcccbHandlers()), 0);
         $this->assertEquals($pc->getClients()[0]->uri, 'uri');
-        $this->assertEquals($pc->getClients()[0]->auth_jwt_claim,
-                array('iss' => 'iss'));
+        $this->assertEquals($pc->getClients()[0]->auth_jwt_claim, array('iss' => 'iss'));
         $this->assertEquals($pc->getClients()[0]->auth_jwt_key, 'key==');
         $this->assertEquals($pc->getClients()[1]->uri, 'uri2');
-        $this->assertEquals($pc->getClients()[1]->auth_jwt_claim,
-                array('iss' => 'iss2'));
+        $this->assertEquals($pc->getClients()[1]->auth_jwt_claim, array('iss' => 'iss2'));
         $this->assertEquals($pc->getClients()[1]->auth_jwt_key, 'key==2');
     }
 
     public function testGripApplyConfig()
     {
         $pc = new GripPubControlTestClass();
-        $pc->apply_grip_config(array(array(
+        $pc->apply_grip_config(array(
+            array(
                 'control_uri' => 'uri',
                 'control_iss' => 'iss',
-                'key' => 'key=='),
-                array('control_uri' => 'uri2',
+                'key' => 'key=='
+            ),
+            array(
+                'control_uri' => 'uri2',
                 'control_iss' => 'iss2',
-                'key' => 'key==2')));
+                'key' => 'key==2'
+            )
+        ));
         $this->assertEquals(count($pc->getClients()), 2);
         $this->assertEquals($pc->getClients()[0]->uri, 'uri');
-        $this->assertEquals($pc->getClients()[0]->auth_jwt_claim,
-                array('iss' => 'iss'));
+        $this->assertEquals($pc->getClients()[0]->auth_jwt_claim, array('iss' => 'iss'));
         $this->assertEquals($pc->getClients()[0]->auth_jwt_key, 'key==');
         $this->assertEquals($pc->getClients()[1]->uri, 'uri2');
-        $this->assertEquals($pc->getClients()[1]->auth_jwt_claim,
-                array('iss' => 'iss2'));
+        $this->assertEquals($pc->getClients()[1]->auth_jwt_claim, array('iss' => 'iss2'));
         $this->assertEquals($pc->getClients()[1]->auth_jwt_key, 'key==2');
         $pc->apply_grip_config(array(
-                'control_uri' => 'uri3',
-                'control_iss' => 'iss3',
-                'key' => 'key==3'));
+            'control_uri' => 'uri3',
+            'control_iss' => 'iss3',
+            'key' => 'key==3'
+        ));
         $this->assertEquals(count($pc->getClients()), 3);
         $this->assertEquals($pc->getClients()[2]->uri, 'uri3');
-        $this->assertEquals($pc->getClients()[2]->auth_jwt_claim,
-                array('iss' => 'iss3'));
+        $this->assertEquals($pc->getClients()[2]->auth_jwt_claim, array('iss' => 'iss3'));
         $this->assertEquals($pc->getClients()[2]->auth_jwt_key, 'key==3');
     }
 
@@ -139,9 +145,15 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $pc->publish_http_response('chan', 'data');
         $this->assertTrue($pcc1->was_publish_called);
         $this->assertEquals($pcc1->publish_channel, 'chan');
-        $this->assertEquals($pcc1->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpResponseFormat(null, null, null,
-                'data')))->export());
+        $this->assertEquals(
+            $pcc1->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpResponseFormat(
+                null,
+                null,
+                null,
+                'data'
+            )))->export()
+        );
     }
 
     public function testPublishHttpResponse2()
@@ -151,13 +163,11 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $pcc2 = new PubControlClientTestClass();
         $pc->add_client($pcc1);
         $pc->add_client($pcc2);
-        $response = new GripControl\HttpResponseFormat('code', 'reason', 'headers',
-                'data');
+        $response = new GripControl\HttpResponseFormat('code', 'reason', 'headers', 'data');
         $pc->publish_http_response('chan', $response, 'id', 'prev-id');
         $this->assertTrue($pcc1->was_publish_called);
         $this->assertEquals($pcc1->publish_channel, 'chan');
-        $this->assertEquals($pcc1->publish_item->export(),
-                (new PubControl\Item($response, 'id', 'prev-id'))->export());
+        $this->assertEquals($pcc1->publish_item->export(), (new PubControl\Item($response, 'id', 'prev-id'))->export());
     }
 
     /**
@@ -179,20 +189,37 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $pc->add_client($pcc1);
         $pc->add_client($pcc2);
         $pc->add_client($pcc3);
-        $pc->publish_http_response_async('chan', 'item', null, null,
-                array($callback, "callback"));
+        $pc->publish_http_response_async('chan', 'item', null, null, array($callback, "callback"));
         $this->assertEquals($pcc1->publish_channel, 'chan');
-        $this->assertEquals($pcc1->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpResponseFormat(null, null, null,
-                'item')))->export());
+        $this->assertEquals(
+            $pcc1->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpResponseFormat(
+                null,
+                null,
+                null,
+                'item'
+            )))->export()
+        );
         $this->assertEquals($pcc2->publish_channel, 'chan');
-        $this->assertEquals($pcc2->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpResponseFormat(null, null, null,
-                'item')))->export());
+        $this->assertEquals(
+            $pcc2->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpResponseFormat(
+                null,
+                null,
+                null,
+                'item'
+            )))->export()
+        );
         $this->assertEquals($pcc3->publish_channel, 'chan');
-        $this->assertEquals($pcc3->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpResponseFormat(null, null, null,
-                'item')))->export());
+        $this->assertEquals(
+            $pcc3->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpResponseFormat(
+                null,
+                null,
+                null,
+                'item'
+            )))->export()
+        );
         call_user_func($pcc1->publish_cb, false, 'message');
         call_user_func($pcc2->publish_cb, false, 'message');
         $this->assertTrue(is_null($callback->result));
@@ -211,8 +238,10 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $pc->publish_http_stream('chan', 'content');
         $this->assertTrue($pcc1->was_publish_called);
         $this->assertEquals($pcc1->publish_channel, 'chan');
-        $this->assertEquals($pcc1->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpStreamFormat('content')))->export());
+        $this->assertEquals(
+            $pcc1->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpStreamFormat('content')))->export()
+        );
     }
 
     public function testPublishHttpStream2()
@@ -226,8 +255,7 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $pc->publish_http_stream('chan', $stream, 'id', 'prev-id');
         $this->assertTrue($pcc1->was_publish_called);
         $this->assertEquals($pcc1->publish_channel, 'chan');
-        $this->assertEquals($pcc1->publish_item->export(),
-                (new PubControl\Item($stream, 'id', 'prev-id'))->export());
+        $this->assertEquals($pcc1->publish_item->export(), (new PubControl\Item($stream, 'id', 'prev-id'))->export());
     }
 
     public function testPublishHttpStreamhAsync()
@@ -240,17 +268,22 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $pc->add_client($pcc1);
         $pc->add_client($pcc2);
         $pc->add_client($pcc3);
-        $pc->publish_http_stream_async('chan', 'item', null, null,
-                array($callback, "callback"));
+        $pc->publish_http_stream_async('chan', 'item', null, null, array($callback, "callback"));
         $this->assertEquals($pcc1->publish_channel, 'chan');
-        $this->assertEquals($pcc1->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpStreamFormat('item')))->export());
+        $this->assertEquals(
+            $pcc1->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpStreamFormat('item')))->export()
+        );
         $this->assertEquals($pcc2->publish_channel, 'chan');
-        $this->assertEquals($pcc2->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpStreamFormat('item')))->export());
+        $this->assertEquals(
+            $pcc2->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpStreamFormat('item')))->export()
+        );
         $this->assertEquals($pcc3->publish_channel, 'chan');
-        $this->assertEquals($pcc3->publish_item->export(),
-                (new PubControl\Item(new GripControl\HttpStreamFormat('item')))->export());
+        $this->assertEquals(
+            $pcc3->publish_item->export(),
+            (new PubControl\Item(new GripControl\HttpStreamFormat('item')))->export()
+        );
         call_user_func($pcc1->publish_cb, false, 'message');
         call_user_func($pcc2->publish_cb, false, 'message');
         $this->assertTrue(is_null($callback->result));
@@ -259,5 +292,3 @@ class TestGripPubControl extends PHPUnit_Framework_TestCase
         $this->assertEquals($callback->message, 'message');
     }
 }
-
-?>

--- a/tests/httpresponseformat_tests.php
+++ b/tests/httpresponseformat_tests.php
@@ -25,15 +25,15 @@ class HttpResponseFormatTests extends PHPUnit_Framework_TestCase
     public function testExport()
     {
         $hf = new GripControl\HttpResponseFormat('code', 'reason', 'headers', 'body');
-        $this->assertEquals($hf->export(), array('code' => 'code',
-                'reason' => 'reason', 'headers' => 'headers',
-                'body' => 'body'));
+        $this->assertEquals($hf->export(), array(
+            'code' => 'code',
+            'reason' => 'reason',
+            'headers' => 'headers',
+            'body' => 'body'
+        ));
         $hf = new GripControl\HttpResponseFormat(null, null, null, "\x04\x00\xa0\x00");
-        $this->assertEquals($hf->export(), array('body-bin' =>
-                base64_encode("\x04\x00\xa0\x00")));
+        $this->assertEquals($hf->export(), array('body-bin' => base64_encode("\x04\x00\xa0\x00")));
         $hf = new GripControl\HttpResponseFormat();
         $this->assertEquals($hf->export(), array());
     }
 }
-
-?>

--- a/tests/httpstreamformat_tests.php
+++ b/tests/httpstreamformat_tests.php
@@ -31,11 +31,8 @@ class HttpStreamFormatTests extends PHPUnit_Framework_TestCase
         $hf = new GripControl\HttpStreamFormat('content');
         $this->assertEquals($hf->export(), array('content' => 'content'));
         $hf = new GripControl\HttpStreamFormat("\x04\x00\xa0\x00");
-        $this->assertEquals($hf->export(), array('content-bin' =>
-                base64_encode("\x04\x00\xa0\x00")));
+        $this->assertEquals($hf->export(), array('content-bin' => base64_encode("\x04\x00\xa0\x00")));
         $hf = new GripControl\HttpStreamFormat('content', true);
         $this->assertEquals($hf->export(), array('action' => 'close'));
     }
 }
-
-?>

--- a/tests/response_tests.php
+++ b/tests/response_tests.php
@@ -16,5 +16,3 @@ class ResponseTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($re->body, 'body');
     }
 }
-
-?>

--- a/tests/websocketevent_tests.php
+++ b/tests/websocketevent_tests.php
@@ -12,5 +12,3 @@ class WebSocketEventTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($we->content, 'content');
     }
 }
-
-?>

--- a/tests/websocketmessageformat_tests.php
+++ b/tests/websocketmessageformat_tests.php
@@ -19,9 +19,6 @@ class WebSocketMessageFormatTests extends PHPUnit_Framework_TestCase
         $wm = new GripControl\WebSocketMessageFormat('content');
         $this->assertEquals($wm->export(), array('content' => 'content'));
         $wm = new GripControl\WebSocketMessageFormat("\x04\x00\xa0\x00");
-        $this->assertEquals($wm->export(), array('content-bin' =>
-                base64_encode("\x04\x00\xa0\x00")));
+        $this->assertEquals($wm->export(), array('content-bin' => base64_encode("\x04\x00\xa0\x00")));
     }
 }
-
-?>


### PR DESCRIPTION
This change does not include changing function naming conventions, class
conventions, namespacing or other major changes to the codebase. It
maintains backwards compatibility and runs the php-cs-fixer PSR-2
styling against the project.

I didn't find a contribution guide, so I am uncertain if I should PR against develop or master. 