### PR TITLE
PSR-2 class structure and PSR-4 autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,14 @@ Requirements
 Installation
 ------------
 
-Using Composer: 'composer require fanout/gripcontrol' 
-
-Manual: ensure that php-jwt and php-pubcontrol have been included and require the following files in php-gripcontrol:
-
-```PHP
-require 'php-gripcontrol/src/encoding.php';
-require 'php-gripcontrol/src/channel.php';
-require 'php-gripcontrol/src/response.php';
-require 'php-gripcontrol/src/websocketevent.php';
-require 'php-gripcontrol/src/websocketmessageformat.php';
-require 'php-gripcontrol/src/httpstreamformat.php';
-require 'php-gripcontrol/src/httpresponseformat.php';
-require 'php-gripcontrol/src/grippubcontrol.php';
-require 'php-gripcontrol/src/gripcontrol.php';
-```
+`composer require fanout/gripcontrol`
 
 Asynchronous Publishing
 -----------------------
 
 In order to make asynchronous publish calls pthreads must be installed. If pthreads is not installed then only synchronous publish calls can be made. To install pthreads recompile PHP with the following flag: '--enable-maintainer-zts'
 
-Also note that since a callback passed to the publish_async methods is going to be executed in a separate thread, that callback and the class it belongs to are subject to the rules and limitations imposed by the pthreads extension.
+Also note that since a callback passed to the `publish_async` method is going to be executed in a separate thread, that callback and the class it belongs to are subject to the rules and limitations imposed by the pthreads extension.
 
 See more information about pthreads here: http://php.net/manual/en/book.pthreads.php
 

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,15 @@
         "phpunit/phpunit": "3.7.14"
     },
     "autoload": {
-        "files": ["src/encoding.php",
-                  "src/websocketmessageformat.php",
-                  "src/websocketevent.php",
-                  "src/httpresponseformat.php",
-                  "src/httpstreamformat.php",
-                  "src/response.php",
-                  "src/channel.php",
-                  "src/grippubcontrol.php",
-                  "src/gripcontrol.php"]
+        "psr-4": {
+            "GripControl\\": "src"
+        }
     },
-    "target-dir": "fanout/php-gripcontrol",
+    "autoload-dev": {
+        "psr-4": {
+            "GripControl\\Test\\": "tests"
+        }
+    },
     "minimum-stability": "dev",
     "scripts": {
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
         bootstrap="./vendor/autoload.php">
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix="tests.php">./tests/</directory>
+            <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  channel.php
+/*  Channel.php
     ~~~~~~~~~
     This module implements the Channel class.
     :authors: Konstantin Bokarius.

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  encoding.php
+/*  Encoding.php
     ~~~~~~~~~
     This module implements the Encoding class.
     :authors: Konstantin Bokarius.

--- a/src/GripControl.php
+++ b/src/GripControl.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  gripcontrol.php
+/*  GripControl.php
     ~~~~~~~~~
     This module implements the GripControl class.
     :authors: Konstantin Bokarius.

--- a/src/GripPubControl.php
+++ b/src/GripPubControl.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  grippubcontrol.php
+/*  GripPubControl.php
     ~~~~~~~~~
     This module implements the GripPubControl class.
     :authors: Konstantin Bokarius.

--- a/src/HttpResponseFormat.php
+++ b/src/HttpResponseFormat.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  httpresponseformat.php
+/*  HttpResponseFormat.php
     ~~~~~~~~~
     This module implements the HttpResponseFormat class.
     :authors: Konstantin Bokarius.

--- a/src/HttpStreamFormat.php
+++ b/src/HttpStreamFormat.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  httpstreamformat.php
+/*  HttpStreamFormat.php
     ~~~~~~~~~
     This module implements the HttpStreamFormat class.
     :authors: Konstantin Bokarius.

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  response.php
+/*  Response.php
     ~~~~~~~~~
     This module implements the Response class.
     :authors: Konstantin Bokarius.

--- a/src/WebSocketEvent.php
+++ b/src/WebSocketEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  websocketevent.php
+/*  WebSocketEvent.php
     ~~~~~~~~~
     This module implements the WebSocketEvent class.
     :authors: Konstantin Bokarius.

--- a/src/WebSocketMessageFormat.php
+++ b/src/WebSocketMessageFormat.php
@@ -1,6 +1,6 @@
 <?php
 
-/*  websocketmessageformat.php
+/*  WebSocketMessageFormat.php
     ~~~~~~~~~
     This module implements the WebSocketMessageFormat class.
     :authors: Konstantin Bokarius.

--- a/tests/ChannelTests.php
+++ b/tests/ChannelTests.php
@@ -1,6 +1,10 @@
 <?php
 
-class ChannelTests extends PHPUnit_Framework_TestCase
+namespace GripControl\Test;
+
+use GripControl;
+
+class ChannelTests extends \PHPUnit_Framework_TestCase
 {
     public function testInitialize()
     {

--- a/tests/EncodingTests.php
+++ b/tests/EncodingTests.php
@@ -1,6 +1,10 @@
 <?php
 
-class EncodingTests extends PHPUnit_Framework_TestCase
+namespace GripControl\Test;
+
+use GripControl;
+
+class EncodingTests extends \PHPUnit_Framework_TestCase
 {
     public function testIsBinaryData()
     {

--- a/tests/Fixtures/CallbackTestClass.php
+++ b/tests/Fixtures/CallbackTestClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GripControl\Test\Fixtures;
+
+class CallbackTestClass extends \Stackable
+{
+    public $was_callback_called = false;
+    public $result = null;
+    public $message = null;
+
+    public function callback($result, $message)
+    {
+        $this->result = $result;
+        $this->message = $message;
+        $this->was_callback_called = true;
+    }
+
+    public function run()
+    {
+    }
+}

--- a/tests/Fixtures/GripControlTestClass.php
+++ b/tests/Fixtures/GripControlTestClass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GripControl\Test\Fixtures;
+
+use GripControl;
+
+class GripControlTestClass extends GripControl\GripControl
+{
+    public static function callParseChannels($channels)
+    {
+        return self::parse_channels($channels);
+    }
+
+    public static function callGetHoldChannels($channels)
+    {
+        return self::get_hold_channels($channels);
+    }
+
+    public static function callGetHoldResponse($response)
+    {
+        return self::get_hold_response($response);
+    }
+}

--- a/tests/Fixtures/GripPubControlTestClass.php
+++ b/tests/Fixtures/GripPubControlTestClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GripControl\Test\Fixtures;
+
+use GripControl;
+
+class GripPubControlTestClass extends GripControl\GripPubControl
+{
+    public function getClients()
+    {
+        return $this->clients;
+    }
+
+    public function getPcccbHandlers()
+    {
+        return $this->pcccbhandlers;
+    }
+}

--- a/tests/Fixtures/GripPubControlTestClassNoAsync.php
+++ b/tests/Fixtures/GripPubControlTestClassNoAsync.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GripControl\Test\Fixtures;
+
+use GripControl;
+
+class GripPubControlTestClassNoAsync extends GripControl\GripPubControl
+{
+    public function is_async_supported()
+    {
+        return false;
+    }
+}

--- a/tests/Fixtures/PubControlClientAsyncTestClass.php
+++ b/tests/Fixtures/PubControlClientAsyncTestClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GripControl\Test\Fixtures;
+
+class PubControlClientAsyncTestClass
+{
+    public $publish_channel = null;
+    public $publish_item = null;
+    public $publish_cb = null;
+
+    public function publish_async($channel, $item, $callback = null)
+    {
+        $this->publish_channel = $channel;
+        $this->publish_item = $item;
+        $this->publish_cb = $callback;
+    }
+}

--- a/tests/Fixtures/PubControlClientTestClass.php
+++ b/tests/Fixtures/PubControlClientTestClass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GripControl\Test\Fixtures;
+
+class PubControlClientTestClass
+{
+    public $was_finish_called = false;
+    public $was_publish_called = false;
+    public $publish_channel = false;
+    public $publish_item = false;
+
+    public function finish()
+    {
+        $this->was_finish_called = true;
+    }
+
+    public function publish($channel, $item)
+    {
+        $this->was_publish_called = true;
+        $this->publish_channel = $channel;
+        $this->publish_item = $item;
+    }
+}

--- a/tests/GripControlTests.php
+++ b/tests/GripControlTests.php
@@ -1,24 +1,11 @@
 <?php
 
-class GripControlTestClass extends GripControl\GripControl
-{
-    public static function callParseChannels($channels)
-    {
-        return self::parse_channels($channels);
-    }
+namespace GripControl\Test;
 
-    public static function callGetHoldChannels($channels)
-    {
-        return self::get_hold_channels($channels);
-    }
+use GripControl;
+use GripControl\Test\Fixtures\GripControlTestClass;
 
-    public static function callGetHoldResponse($response)
-    {
-        return self::get_hold_response($response);
-    }
-}
-
-class GripControlTests extends PHPUnit_Framework_TestCase
+class GripControlTests extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException RuntimeException

--- a/tests/GripPubControlTest.php
+++ b/tests/GripPubControlTest.php
@@ -1,79 +1,16 @@
 <?php
 
-class GripPubControlTestClass extends GripControl\GripPubControl
-{
-    public function getClients()
-    {
-        return $this->clients;
-    }
+namespace GripControl\Test;
 
-    public function getPcccbHandlers()
-    {
-        return $this->pcccbhandlers;
-    }
-}
+use GripControl;
+use GripControl\Test\Fixtures\GripPubControlTestClass;
+use GripControl\Test\Fixtures\PubControlClientTestClass;
+use GripControl\Test\Fixtures\PubControlClientAsyncTestClass;
+use GripControl\Test\Fixtures\GripPubControlTestClassNoAsync;
+use GripControl\Test\Fixtures\CallbackTestClass;
+use PubControl;
 
-class PubControlClientTestClass
-{
-    public $was_finish_called = false;
-    public $was_publish_called = false;
-    public $publish_channel = false;
-    public $publish_item = false;
-
-    public function finish()
-    {
-        $this->was_finish_called = true;
-    }
-
-    public function publish($channel, $item)
-    {
-        $this->was_publish_called = true;
-        $this->publish_channel = $channel;
-        $this->publish_item = $item;
-    }
-}
-
-class PubControlClientAsyncTestClass
-{
-    public $publish_channel = null;
-    public $publish_item = null;
-    public $publish_cb = null;
-
-    public function publish_async($channel, $item, $callback = null)
-    {
-        $this->publish_channel = $channel;
-        $this->publish_item = $item;
-        $this->publish_cb = $callback;
-    }
-}
-
-class GripPubControlTestClassNoAsync extends GripControl\GripPubControl
-{
-    public function is_async_supported()
-    {
-        return false;
-    }
-}
-
-class CallbackTestClass extends Stackable
-{
-    public $was_callback_called = false;
-    public $result = null;
-    public $message = null;
-
-    public function callback($result, $message)
-    {
-        $this->result = $result;
-        $this->message = $message;
-        $this->was_callback_called = true;
-    }
-
-    public function run()
-    {
-    }
-}
-
-class TestGripPubControl extends PHPUnit_Framework_TestCase
+class GripPubControlTest extends \PHPUnit_Framework_TestCase
 {
     public function testInitialize()
     {

--- a/tests/HttpResponseFormatTests.php
+++ b/tests/HttpResponseFormatTests.php
@@ -1,6 +1,10 @@
 <?php
 
-class HttpResponseFormatTests extends PHPUnit_Framework_TestCase
+namespace GripControl\Test;
+
+use GripControl;
+
+class HttpResponseFormatTests extends \PHPUnit_Framework_TestCase
 {
     public function testIntialize()
     {

--- a/tests/HttpStreamFormatTests.php
+++ b/tests/HttpStreamFormatTests.php
@@ -1,6 +1,10 @@
 <?php
 
-class HttpStreamFormatTests extends PHPUnit_Framework_TestCase
+namespace GripControl\Test;
+
+use GripControl;
+
+class HttpStreamFormatTests extends \PHPUnit_Framework_TestCase
 {
     public function testIntialize()
     {

--- a/tests/ResponseTests.php
+++ b/tests/ResponseTests.php
@@ -1,6 +1,10 @@
 <?php
 
-class ResponseTests extends PHPUnit_Framework_TestCase
+namespace GripControl\Test;
+
+use GripControl;
+
+class ResponseTests extends \PHPUnit_Framework_TestCase
 {
     public function testIntialize()
     {

--- a/tests/WebSocketEventTests.php
+++ b/tests/WebSocketEventTests.php
@@ -1,6 +1,10 @@
 <?php
 
-class WebSocketEventTests extends PHPUnit_Framework_TestCase
+namespace GripControl\Test;
+
+use GripControl;
+
+class WebSocketEventTests extends \PHPUnit_Framework_TestCase
 {
     public function testInitialize()
     {

--- a/tests/WebSocketMessageFormatTests.php
+++ b/tests/WebSocketMessageFormatTests.php
@@ -1,6 +1,10 @@
 <?php
 
-class WebSocketMessageFormatTests extends PHPUnit_Framework_TestCase
+namespace GripControl\Test;
+
+use GripControl;
+
+class WebSocketMessageFormatTests extends \PHPUnit_Framework_TestCase
 {
     public function testIntialize()
     {


### PR DESCRIPTION
This change ensures there is only one class definition per file and defines PSR-4 autoloading. If anyone is using manual loading of the files, this change will break it. 